### PR TITLE
Separate chatbot and amplifier

### DIFF
--- a/chatgpt_api.py
+++ b/chatgpt_api.py
@@ -67,6 +67,9 @@ class Chatbot:
         """
         Add a message to the conversation
         """
+        # Make conversation if it doesn't exist
+        if convo_id not in self.conversation:
+            self.reset(convo_id=convo_id, system_prompt=self.system_prompt)
         self.conversation[convo_id].append({"role": role, "content": message})
 
     def __truncate_conversation(self, convo_id: str = "default") -> None:

--- a/redditbot.py
+++ b/redditbot.py
@@ -3,12 +3,13 @@ import re
 import time
 import random
 import threading
-from climategpt import get_raw_response
+from climategpt import get_response
 from credentials import client_id as CLIENT_ID, client_secret as CLIENT_SECRET, r_password as PASSWORD
 
 # Replace with your own values
 USERNAME = "ClimateGPT"
 USER_AGENT = "macos:climatebot:1.0 (by /u/ClimateGPT)"
+MAX_CHECK_TIMES = 1000
 
 # Create a Reddit instance
 reddit = praw.Reddit(
@@ -26,7 +27,9 @@ def monitor_thread(thread_id: str):
 
     # Monitor the thread for new comments
     print(f"start checking reddit thread {thread_id}...")
-    while True:
+    check_counter = 0
+    while check_counter < MAX_CHECK_TIMES:
+        check_counter += 1
         thread.comments.replace_more(limit=None)
         for comment in thread.comments.list():
             # Check if the comment was published after the last comment we have seen
@@ -34,15 +37,13 @@ def monitor_thread(thread_id: str):
                 last_comment_time = comment.created_utc
 
                 # print("==========\n" + "is_root:" + str(comment.is_root) + "\nbody:" + comment.body +
-                #       "\nauthor:" + str(comment.author) + \
-                #     #   "\nreplies:" + str(comment.replies) + 
-                #     "\n==========")
+                #       "\nauthor:" + str(comment.author) + "\n==========")
 
                 # Check for others' comments that are not responded yet
                 if comment.author != reddit.user.me() and not any(reply.author == reddit.user.me() for reply in comment.replies):
-                    # Matching key word
-                    if re.search(r"climate change", comment.body, re.IGNORECASE):
-                        reply_text = get_raw_response(comment.body)
+                    # Simply reply all comments
+                    if True or re.search(r"climate change", comment.body, re.IGNORECASE):
+                        reply_text = get_response(comment.body)
                         comment.reply(reply_text)
                         print(
                             f"Replied to comment by u/{comment.author}: {reply_text}")


### PR DESCRIPTION
Previously, we use both chatbot and amplifier in text conversation where chatbot generates a raw response and amplifier modifies the response. Despite more intentionally curated responses related to climate change, there are inevitably two roundtrips to openai's /chat API calls. To reduce latency induced, we experimented with using only chatbot for typical text conversations, whereas using only amplifier for image generation prompts.